### PR TITLE
Clarify Command Line Build Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 out/
 .vs/
 .vscode/
+CMakeFiles/
 *.dll
 *.exp
 *.lib
 *.ilk
 *.pdb
+build.ninja
+cmake_install.cmake
+CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Requires cmake, ninja and VS Toolchain (usually all included with Visual Studio 
         2. Select x64-release
         3. In the command pallet run ```CMake: Build```
     - Command Line - CMake with Ninja (VS Developer Command Prompt):
-        1. ```cmake -G ninja .```
-        2. ```cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_INSTALL_PREFIX=./dcs-lua-imgui/out/install/x64-release -S. -B./out/build/x64-release -G Ninja```
+        1. ```cmake -G "Ninja" .```
+        2. ```cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl.exe -DCMAKE_C_FLAGS="/MACHINE:X64" -DCMAKE_CXX_FLAGS="/MACHINE:X64" -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_INSTALL_PREFIX=./dcs-lua-imgui/out/install/x64-release -S. -B./out/build/x64-release -G Ninja```
         3. ```cmake --build out/build/x64-release --parallel 30```
 
 2. Copy LuaImGui folder to Cockpit/Scripts (if it isn't there)


### PR DESCRIPTION
I was unable to build without these changes to the command line build instructions.